### PR TITLE
Remove unnecessary `Ref` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ ppp = "2"
 tokio = { version = "1", features = [] }
 tokio-util =  { version = "0.7", features = ["io"] }
 futures-util = "0.3"
-pin-project-lite = "0.2"
 
 [dev-dependencies]
 tokio-util =  { version = "0.7", features = ["io-util"] }


### PR DESCRIPTION
These types are actually not needed since one can use a `PPPFuture<Pin<&mut T>>` or `PPPFuture<&mut T>` instead. It simplifies the implementation and API significantly to just have the `PPPFuture` and `PPPStream` types.